### PR TITLE
add rotation direction check to labware offset correction

### DIFF
--- a/src/science_jubilee/labware/Labware.py
+++ b/src/science_jubilee/labware/Labware.py
@@ -690,7 +690,6 @@ class Labware(WellSet):
             # in this case, plate is rotated down
             theta = -1 * theta
 
-
         # apply offset to all wells in the labware object
 
         for well in self:

--- a/src/science_jubilee/labware/Labware.py
+++ b/src/science_jubilee/labware/Labware.py
@@ -684,6 +684,13 @@ class Labware(WellSet):
         theta1 = acos((upper_right[1] - bottom_right[1]) / plate_height)
         theta2 = acos((upper_right[0] - upper_left[0]) / plate_width)
         theta = (theta1 + theta2) / 2.0
+
+        # Apply direction correction to theta
+        if (upper_right[1] < upper_left[1]) and (bottom_right[0] < upper_right[0]):
+            # in this case, plate is rotated down
+            theta = -1 * theta
+
+
         # apply offset to all wells in the labware object
 
         for well in self:


### PR DESCRIPTION
There was indeed a bug in the labware rotation code in the manual offset update. The method for calculating the rotation angle calculates the magnitude of theta, but not the direction. If your labware is rotated 'up' this works fine, but if it is rotated 'down' slightly you wind up with incorrect well positions b/c the rotation correction is applied as if it were rotated up. This fix just adds a line to check the relative values of the X and Y teaching points. If they are consistent with a down-rotated point, it just flips theta. 