### PR TITLE
Bug fix in lab automation bed.g file

### DIFF
--- a/tool_library/bed_plate/duet_config/bed.g
+++ b/tool_library/bed_plate/duet_config/bed.g
@@ -1,14 +1,14 @@
-M290 R0 S0                 ; Reset baby stepping
-M561                       ; Disable any Mesh Bed Compensation
+M290 R0 S0                   ; Reset baby stepping
+M561                         ; Disable any Mesh Bed Compensation
 
-G1 Z50 ; pop bed down
-G1 X195 Y40 ; move near back leadscrew
-G30 P0 X195 Y40 Z-99999   ; probe near back leadscrew
+G1 Z50                       ; pop bed down
+G1 X195 Y40                  ; move near back leadscrew
+G30 P0 X195 Y40 Z-99999      ; probe near back leadscrew
 G1 Z50 ; pop bed down
 G1 X240 Y270
-G30 P1 X240 Y270 Z-99999    ; probe near front left leadscrew
+G30 P1 X240 Y270 Z-99999     ; probe near front left leadscrew
 G1 Z50
 G1 X65 Y270
 G30 P2 X65 Y270 Z-99999 S3   ; probe near front right leadscrew and calibrate 3 motors
-G1 Z100 ; pop bed down when finished
-G29 S1                     ; Enable Mesh Bed Compensation
+G29 S1                       ; Enable Mesh Bed Compensation
+G1 Z100                      ; pop bed down when finished


### PR DESCRIPTION
<!--
  Thanks for contributing! Please use this pull request (PR) template.


 In the description field of this PR, tag the issue you are fixing (e.g. #XXXX). If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), please say so.-->

 Changes:
<!-- Describe the changes which were made in this pull request; this can be a bullet point list. -->

In bed.g, the bed is being popped down before mesh bed compensation; it should be happening after. This PR just swaps the command order in the bed.g duet config file
#### PR Checklist
<!--
  To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab! Feel free to remove any portion of the template that is not relevant for your issue.
-->

